### PR TITLE
Updating to CakePHP 3.6 and Fixing Type Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Cakephp3 impersonate plugin. A component that store current session and create new session for impersonating. User can revert back to original sessions without the needs to re-login.
 
 # Requirement
-1. Cakephp 3.4 and above.
+1. Cakephp 3.6 and above.
 2. Use of default Cakephp AuthComponent.
 
 # Installation

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "license": "MIT",
     "require": {
-        "cakephp/cakephp": "^3.4"
+        "cakephp/cakephp": "^3.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0"

--- a/src/Controller/Component/ImpersonateComponent.php
+++ b/src/Controller/Component/ImpersonateComponent.php
@@ -49,11 +49,11 @@ class ImpersonateComponent extends Component
         
         $this->controller->loadModel('Users');
         
-        $originalAuth = $this->request->session()->read('Auth');
+        $originalAuth = $this->request->getSession()->read('Auth');
         
         $users = $this->controller->Users->get($id);
         $this->controller->Auth->setUser($users);
-        $this->request->session()->write('OriginalAuth',$originalAuth);
+        $this->request->getSession()->write('OriginalAuth',$originalAuth);
        
         return true;
     }
@@ -66,7 +66,7 @@ class ImpersonateComponent extends Component
      */
     public function isImpersonate() {
         
-        if($this->request->session()->read('OriginalAuth')){
+        if($this->request->getSession()->read('OriginalAuth')){
             return true;
         }
         
@@ -83,9 +83,9 @@ class ImpersonateComponent extends Component
         
         if($this->isImpersonate()) {
             $Auth = $this->request->session()->read('OriginalAuth');
-             $this->request->session()->write('Auth',$Auth);
+             $this->request->getSession()->write('Auth',$Auth);
             
-            $this->request->session()->delete('OriginalAuth');
+            $this->request->getSession()->delete('OriginalAuth');
         }
         
         return true;

--- a/src/Controller/Component/ImpersonateComponent.php
+++ b/src/Controller/Component/ImpersonateComponent.php
@@ -52,7 +52,7 @@ class ImpersonateComponent extends Component
         $originalAuth = $this->request->getSession()->read('Auth');
         
         $users = $this->controller->Users->get($id);
-        $this->controller->Auth->setUser($users);
+        $this->controller->Auth->setUser($users->toArray());
         $this->request->getSession()->write('OriginalAuth',$originalAuth);
        
         return true;


### PR DESCRIPTION
Updating this project to use CakePHP 3.6, Cleaning up Deprecated Warnings cause by CakePHP 3.6, resolving Type bug when calling `$AuthComponent->setUser($user)` As the $user should be an array. This Plugin was passing in the entity.