### PR TITLE
Adds suggestions from #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 # Impersonate Component
 A component that stores the current authentication session and creates new session for impersonating Users. User can revert back to original authentication sessions without the need to re-login.
 
+### Warning
+Always double check that you cannot "spoof" other users in the controller actions. To prevent hijacking of users accounts that the current authenticated User shouldn't/wouldn't have normal access to. This Plugin does circumvent default authentication mechanisms.
+
 # Requirement
 1. CakePHP 3.7 and above.
 
@@ -31,12 +34,12 @@ $this->loadComponent('CakeImpersonate.Impersonate');
 # Usage
 #### Impersonate user
 ```php
-$this->Impersonate->login($targeted_user_id);
+$this->Impersonate->login($user_id);
 ```
 
-#### Check current user is impersonating
+#### Check current user is impersonated
 ```php
-$this->Impersonate->isImpersonate();
+$this->Impersonate->isImpersonated();
 ```
 
 #### Logout from impersonating

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
         <ini name="apc.enable_cli" value="1"/>
         <!-- E_ALL => 32767 -->
         <!-- E_ALL & ~E_USER_DEPRECATED => 16383 -->
-        <ini name="error_reporting" value="32767"/>
+        <ini name="error_reporting" value="16383"/>
     </php>
 
     <!-- Add any additional test suites you want to run here -->

--- a/tests/TestCase/Controller/Component/ImpersonateComponentTest.php
+++ b/tests/TestCase/Controller/Component/ImpersonateComponentTest.php
@@ -68,12 +68,20 @@ class ImpersonateComponentTest extends TestCase
     /**
      * @return void
      */
-    public function testIsImpersonate()
+    public function testIsImpersonated()
     {
         $this->assertFalse($this->Impersonate->Impersonate->isImpersonated());
 
         $this->Impersonate->getRequest()->getSession()->write('OriginalAuth', $this->Auth);
         $this->assertTrue($this->Impersonate->Impersonate->isImpersonated());
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsImpersonate()
+    {
+        $this->assertFalse($this->Impersonate->Impersonate->isImpersonate());
     }
 
     /**

--- a/tests/TestCase/Controller/Component/ImpersonateComponentTest.php
+++ b/tests/TestCase/Controller/Component/ImpersonateComponentTest.php
@@ -3,8 +3,6 @@ namespace App\Test\TestCase\Controller\Component;
 
 use App\Controller\ImpersonateTestController;
 use Cake\Core\Configure;
-use Cake\Datasource\Exception\RecordNotFoundException;
-use Cake\Event\Event;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
@@ -72,10 +70,10 @@ class ImpersonateComponentTest extends TestCase
      */
     public function testIsImpersonate()
     {
-        $this->assertFalse($this->Impersonate->Impersonate->isImpersonate());
+        $this->assertFalse($this->Impersonate->Impersonate->isImpersonated());
 
         $this->Impersonate->getRequest()->getSession()->write('OriginalAuth', $this->Auth);
-        $this->assertTrue($this->Impersonate->Impersonate->isImpersonate());
+        $this->assertTrue($this->Impersonate->Impersonate->isImpersonated());
     }
 
     /**
@@ -95,7 +93,7 @@ class ImpersonateComponentTest extends TestCase
     {
         $this->Impersonate->Impersonate->setConfig('stayLoggedIn', false);
         $this->Impersonate->getRequest()->getSession()->write('OriginalAuth', $this->Auth);
-        $this->assertSame('/', $this->Impersonate->Impersonate->logout(new Event('Auth.logout')));
+        $this->assertSame('/', $this->Impersonate->Impersonate->logout());
     }
 
     /**


### PR DESCRIPTION
Adds warning about circumventing default auth mechnanisms.
Deprecates `ImpersonateComponent::isImpersonate()` you should instead use `ImpersonateComponent::isImpersonated()`

Fixes #8 